### PR TITLE
Dockerise the project and add support for redis-rb 4.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:3.0
+
+WORKDIR /usr/local/src/rolling-limit
+
+COPY lib/rolling/limit/version.rb ./lib/rolling/limit/
+# Preinstall latest gems specified by gemspec; note that they may be overwritten by Gemfile.lock from mounted app dir
+COPY Gemfile rolling-limit.gemspec ./
+
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ TODO: Write usage instructions here
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+Run `docker-compose build` to build a Docker image. You can then run `docker-compose run --rm app bundle exec rspec` to run automated tests.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/livelink/rolling-limit.
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  app:
+    build: .
+    environment:
+      - REDIS_HOST=redis
+    volumes:
+      - .:/usr/local/src/rolling-limit
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:6

--- a/lib/rolling/limit/version.rb
+++ b/lib/rolling/limit/version.rb
@@ -1,5 +1,5 @@
 module Rolling
   class Limit
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/rolling-limit.gemspec
+++ b/rolling-limit.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis", "~> 3.0"
+  spec.add_dependency "redis", '>= 3.0.0', '< 5.0'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/rolling-limit.gemspec
+++ b/rolling-limit.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "redis", "~> 3.0"
-  spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/rolling/limit_spec.rb
+++ b/spec/rolling/limit_spec.rb
@@ -5,7 +5,12 @@ describe Rolling::Limit do
     expect(Rolling::Limit::VERSION).not_to be nil
   end
 
-  let(:redis) { Redis.new }
+  let(:redis_config) do
+    config = {}
+    config[:host] = ENV['REDIS_HOST'] if ENV['REDIS_HOST']
+    config
+  end
+  let(:redis) { Redis.new(redis_config) }
   let(:subject) do
    described_class.new(redis: redis,
                        key: 'test-rate-limit',


### PR DESCRIPTION
### Summary

Rolling-limit doesn't allow working with modern `redis-rb` gem, so I loosened the restrictions.

The tests are relying on an actual Redis instance, so I dockerised the project to remove need for Redis on the host when running automated tests.

Finally, I bumped the version so that the gem can be released straight away.

### Bonus: changelog for redis-rb 4.0
```
- Removed Redis.connect. Use Redis.new.
- Removed Redis#[] and Redis#[]= aliases.
- Added support for CLIENT commands. The lower-level client can be accessed via Redis#_client.
- Dropped official support for Ruby < 2.2.2.
```
[Source](https://github.com/redis/redis-rb/blob/5dd7df9310b1bac97b4ae0385faf7ba6c0fee1d2/CHANGELOG.md#40)