### PR TITLE
KBZ-8200 gems(upgrade): redis ~> 5.0

### DIFF
--- a/lib/rolling/limit/version.rb
+++ b/lib/rolling/limit/version.rb
@@ -1,5 +1,5 @@
 module Rolling
   class Limit
-    VERSION = "0.1.2"
+    VERSION = "0.2.0"
   end
 end

--- a/rolling-limit.gemspec
+++ b/rolling-limit.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis", '>= 3.0.0', '< 5.0'
+  spec.add_dependency "redis", '~> 5.0'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
# Background
It's locking the upgrade of redis to version 5 or greater. 

# Solution
Upgrade the dependancy to redis ~> 5.0

# Notes
I've executed  the specs after the upgrade and they looks OK.
![image](https://user-images.githubusercontent.com/10981611/229109071-b5201ccb-4af9-47b6-8bfd-5f02e92b9da3.png)


ref: [KBZ-8200](https://livelinktechnology.kanbanize.com/ctrl_board/20/cards/8200/details/)